### PR TITLE
VSTS-105 - Server Rebuild

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 deployment_host: github.com
+bundler_version: '~> 1.17.3'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Alberta Motor Association
-  description: Rails Dependencies and Installation for Ubuntu 16.04
+  description: Rails Dependencies and Installation for Ubuntu
   company: Alberta Motor Association
 
   license: MIT
@@ -10,7 +10,9 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+      - trusty
       - xenial
+      - bionic
   galaxy_tags:
     - rails
     - bundler

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,35 +1,52 @@
 ---
 - name: Install Nokogiri requirements
-  apt: pkg={{ item }} state=latest
-  with_items:
-    - libxslt1-dev
-    - libxml2-dev
+  apt:
+    pkg:
+      - libxslt1-dev
+      - libxml2-dev
+    state: latest
 
 - name: Install Ruby FFI
-  apt: pkg={{ item }} state=latest
-  with_items:
-    - libffi6
-    - libffi-dev
-
-- name: Check bundler version
-  shell: bundler --version
-  register: version_of_bundler_installed
-  ignore_errors: yes
+  apt:
+    pkg:
+      - libffi6
+      - libffi-dev
+    state: latest
 
 - name: Install Bundler as a system gem
-  command: gem install bundler
-  when: version_of_bundler_installed.stderr != ""
-
-- name: Symlink Rails logs to common area
-  file: src=/srv/{{ app_name }}/shared/log dest=/var/log/rails state=link force=yes
+  gem:
+    name: bundler
+    user_install: no
+    version: '{{ bundler_version }}'
+    state: present
 
 - name: Create directory for app
-  file: state=directory path=/srv/{{ app_name }} owner={{ deployer }} group={{ deployer }}
+  file:
+    state: directory
+    path: '/srv/{{ app_name }}'
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
+
+- name: Create Shared Directory to Bootstrap Capistrano
+  file:
+    state: directory
+    path: '/srv/{{ app_name }}/shared'
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
+
+- name: Symlink Rails logs to common area
+  file:
+    src: '/srv/{{ app_name }}/shared/log'
+    dest: '/var/log/rails'
+    state: link
+    force: yes
 
 - name: Fetch SSH host keys for {{ deployment_host }}
-  command: ssh-keyscan {{ deployment_host }}
-  register: known_hosts_keys
+  command: ssh-keyscan -t rsa {{ deployment_host }}
+  register: deployment_host_key
 
-- name: Add host key to known_hosts file
-  lineinfile: create=yes dest=/etc/ssh/ssh_known_hosts line='{{ known_hosts_keys.stdout }}' state=present owner=root group=root mode=0644
-  when: known_hosts_keys
+- name: Install SSH host keys for {{ deployment_host }}
+  known_hosts:
+    name: '{{ deployment_host }}'
+    state: present
+    key: '{{ deployment_host_key.stdout }}'


### PR DESCRIPTION
:elephant:

* Bring the syntax up-to-date with modern ansible syntax.
* Don't loop over apt dependencies - instead pass an array
  to resolve a deprecation warning.
* Create a `shared` directory so we can bootstrap the capistrano
  deployment as this directory is required.
* Use the `known_hosts` module to ensure github is accepted
  as a known host.