### PR TITLE
ADO-14316 - Ubuntu 20.04

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 deployment_host: github.com
-bundler_version: '~> 1.17.3'
+bundler_version: '~> 2.0'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
       - trusty
       - xenial
       - bionic
+      - focal
   galaxy_tags:
     - rails
     - bundler

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,13 +4,7 @@
     pkg:
       - libxslt1-dev
       - libxml2-dev
-    state: latest
-
-- name: Install Ruby FFI
-  apt:
-    pkg:
-      - libffi6
-      - libffi-dev
+      - zlib1g-dev
     state: latest
 
 - name: Install Bundler as a system gem
@@ -40,6 +34,21 @@
     dest: '/var/log/rails'
     state: link
     force: yes
+
+- name: Create Bundler Directory
+  file:
+    path: '/home/{{ deployer }}/.bundle'
+    state: directory
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
+
+- name: Configure Bundler
+  template:
+    src: templates/bundler.j2
+    dest: '/home/{{ deployer }}/.bundle/config'
+    mode: '0644'
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
 
 - name: Fetch SSH host keys for {{ deployment_host }}
   command: ssh-keyscan -t rsa {{ deployment_host }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,23 @@
       - zlib1g-dev
     state: latest
 
+- name: Add APT Public Key for Yarn
+  apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
+
+- name: Add APT Repository for Yarn
+  apt_repository:
+    repo: deb https://dl.yarnpkg.com/debian/ stable main
+    state: present
+
+- name: Install Yarn and NodeJS
+  apt:
+    update_cache: yes
+    name: yarn
+    install_recommends: yes # nodejs
+    state: latest
+
 - name: Install Bundler as a system gem
   gem:
     name: bundler
@@ -25,6 +42,34 @@
   file:
     state: directory
     path: '/srv/{{ app_name }}/shared'
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
+
+- name: App Directory | tmp
+  file:
+    state: directory
+    path: '/srv/{{ app_name }}/shared/tmp'
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
+
+- name: App Directory | tmp/cache
+  file:
+    state: directory
+    path: '/srv/{{ app_name }}/shared/tmp/cache'
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
+
+- name: App Directory | tmp/sockets
+  file:
+    state: directory
+    path: '/srv/{{ app_name }}/shared/tmp/sockets'
+    owner: '{{ deployer }}'
+    group: '{{ deployer }}'
+
+- name: App Directory | tmp/pids
+  file:
+    state: directory
+    path: '/srv/{{ app_name }}/shared/tmp/pids'
     owner: '{{ deployer }}'
     group: '{{ deployer }}'
 

--- a/templates/bundler.j2
+++ b/templates/bundler.j2
@@ -1,0 +1,3 @@
+BUNDLE_DEPLOYMENT: "true"
+BUNDLE_PATH: "/srv/{{ app_name }}/shared/bundle"
+BUNDLE_WITHOUT: "development:test"


### PR DESCRIPTION
* Update role for ubuntu 20.04.
* No longer lock bundler version to 1.X. Instead we'll lock to
  2.X and configure bundler using a template for production use.
* No longer install libffi as it's not necessary for app deployment.
* Install zlib1g-dev as it's required by AWS ARM images to build
  nokogiri.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/14316